### PR TITLE
Bump pillow from 9.5.0 to 10.3.0 in the pip group across 1 directory

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ httpx[http2]==0.25.2
 motor
 numpy
 opencv-python
-pillow==9.5.0
+pillow==10.3.0
 psutil
 py-tgcalls==0.9.7
 pykeyboard


### PR DESCRIPTION
Bumps the pip group with 1 update in the / directory: [pillow](https://github.com/python-pillow/Pillow).


Updates `pillow` from 9.5.0 to 10.3.0
- [Release notes](https://github.com/python-pillow/Pillow/releases)
- [Changelog](https://github.com/python-pillow/Pillow/blob/main/CHANGES.rst)
- [Commits](https://github.com/python-pillow/Pillow/compare/9.5.0...10.3.0)

---
updated-dependencies:
- dependency-name: pillow dependency-version: 10.3.0 dependency-type: direct:production dependency-group: pip ...